### PR TITLE
fix: Ensure document lang setting is properly ignored on fastboot

### DIFF
--- a/packages/ember-l10n/addon/services/l10n.js
+++ b/packages/ember-l10n/addon/services/l10n.js
@@ -121,7 +121,7 @@ export default class L10nService extends Service {
     this.locale = locale;
 
     // Ensure lang attribute is set on html tag
-    document?.documentElement.setAttribute('lang', locale);
+    window.document?.documentElement.setAttribute('lang', locale);
   }
 
   detectLocale() {


### PR DESCRIPTION
As apparently `document?.` lead to an error when document is not defined.