### PR TITLE
Use `Intl.PluralRules()` instead of regex for plural-forms header

### DIFF
--- a/packages/ember-l10n/README.md
+++ b/packages/ember-l10n/README.md
@@ -29,7 +29,6 @@ let ENV = {
   '@ember-gettext/ember-l10n': {
     locales: ['en', 'de', 'ko'],
     defaultLocale: 'en', // defaults value
-    defaultPluralForm: 'nplurals=2; plural=(n != 1);', // default value
   },
 };
 ```

--- a/packages/ember-l10n/addon/utils/plural-factory.js
+++ b/packages/ember-l10n/addon/utils/plural-factory.js
@@ -1,0 +1,25 @@
+const PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
+
+export class PluralFactory {
+  locale;
+  pluralRules;
+  pluralForms;
+
+  constructor(locale) {
+    this.locale = locale;
+    this.pluralRules = new Intl.PluralRules(locale);
+
+    // We want to ensure a stable sorting
+    // As this could be in any order, but gettext will try to keep a stable ordering from few->many
+    let pluralForms = this.pluralRules.resolvedOptions().pluralCategories;
+
+    this.pluralForms = PLURAL_FORMS.filter((pluralForm) =>
+      pluralForms.includes(pluralForm)
+    );
+  }
+
+  getMessageIndex(count) {
+    let pluralForm = this.pluralRules.select(count);
+    return this.pluralForms.indexOf(pluralForm);
+  }
+}

--- a/packages/ember-l10n/tests/helpers/mock-locale.js
+++ b/packages/ember-l10n/tests/helpers/mock-locale.js
@@ -1,4 +1,11 @@
-export function mockLocale(l10nService, translations, messageContext = '') {
+import { PluralFactory } from '@ember-gettext/ember-l10n/utils/plural-factory';
+
+export function mockLocale(
+  l10nService,
+  translations,
+  messageContext = '',
+  { locale } = { locale: 'en' }
+) {
   let poTranslations = {};
 
   Object.keys(translations).forEach((msgid) => {
@@ -17,4 +24,7 @@ export function mockLocale(l10nService, translations, messageContext = '') {
       [messageContext]: poTranslations,
     }
   );
+
+  l10nService.locale = locale;
+  l10nService.pluralFactory = new PluralFactory(locale);
 }

--- a/packages/ember-l10n/tests/integration/helpers/n-test.js
+++ b/packages/ember-l10n/tests/integration/helpers/n-test.js
@@ -28,7 +28,7 @@ module('Integration | Helper | n', function (hooks) {
   test('it works without placeholders and count -1', async function (assert) {
     await render(hbs`{{n 'this is one' 'this is multiple' -1}}`);
 
-    assert.dom(this.element).hasText('this is multiple');
+    assert.dom(this.element).hasText('this is one');
   });
 
   test('it automatically provides count placeholder', async function (assert) {

--- a/packages/ember-l10n/tests/unit/services/l10n-test.js
+++ b/packages/ember-l10n/tests/unit/services/l10n-test.js
@@ -275,4 +275,177 @@ module('Unit | Service | l10n', function (hooks) {
       'XX john doe 1.'
     );
   });
+
+  module('plurals', function () {
+    test('it works with existing translation (de)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+      mockLocale(
+        l10n,
+        {
+          'I have {{count}} point.': [
+            'Ich habe {{count}} Punkt.',
+            'Ich habe {{count}} Punkte.',
+          ],
+        },
+        '',
+        { locale: 'de' }
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 0),
+        'Ich habe 0 Punkte.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 1),
+        'Ich habe 1 Punkt.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 2),
+        'Ich habe 2 Punkte.'
+      );
+    });
+
+    test('it works with missing translation (de)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+
+      mockLocale(
+        l10n,
+        {
+          'I have {{count}} point.': [],
+        },
+        '',
+        { locale: 'de' }
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 0),
+        'I have 0 points.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 1),
+        'I have 1 point.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 2),
+        'I have 2 points.'
+      );
+    });
+
+    // ko locale only has one singlular/plural form
+    test('it works with existing translation (ko)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+      mockLocale(
+        l10n,
+        {
+          'I have {{count}} point.': ['XXX YYY {{count}}.'],
+        },
+        '',
+        { locale: 'ko' }
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 0),
+        'XXX YYY 0.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 1),
+        'XXX YYY 1.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 2),
+        'XXX YYY 2.'
+      );
+    });
+
+    test('it works with missing translation (ko)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+
+      mockLocale(
+        l10n,
+        {
+          'I have {{count}} point.': [],
+        },
+        '',
+        { locale: 'ko' }
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 0),
+        'I have 0 points.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 1),
+        'I have 1 point.'
+      );
+
+      assert.equal(
+        l10n.n('I have {{count}} point.', 'I have {{count}} points.', 2),
+        'I have 2 points.'
+      );
+    });
+
+    // ar has all possible forms: zero, one, two, few, many, other
+    test('it works with existing translation (ar)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+      mockLocale(
+        l10n,
+        {
+          '{{count}} item': ['zero', 'one', 'two', 'few', 'many', 'other'],
+        },
+        '',
+        { locale: 'ar-eg' }
+      );
+
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 0), 'zero');
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 1), 'one');
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 2), 'two');
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 4), 'few');
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 8), 'few');
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 15), 'many');
+      assert.equal(l10n.n('{{count}} item', '{{count}} items', 100), 'other');
+    });
+
+    test('it asserts if trying to use missing plural form (de)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+      mockLocale(
+        l10n,
+        {
+          'I have {{count}} point.': ['Ich habe {{count}} Punkt.'],
+        },
+        '',
+        { locale: 'de' }
+      );
+
+      assert.throws(
+        () => l10n.n('I have {{count}} point.', 'I have {{count}} points.', 0),
+        /Assertion Failed: Message with index 1 is not found for count=0/,
+        'it throws an error'
+      );
+    });
+
+    test('it asserts if trying to use missing plural form (ar)', async function (assert) {
+      let l10n = this.owner.lookup('service:l10n');
+      mockLocale(
+        l10n,
+        {
+          '{{count}} item': ['zero', 'one', 'two', 'few', 'many'],
+        },
+        '',
+        { locale: 'ar-eg' }
+      );
+
+      assert.throws(
+        () => l10n.n('{{count}} item', '{{count}} items', 100),
+        /Assertion Failed: Message with index 5 is not found for count=100/,
+        'it throws an error'
+      );
+    });
+  });
 });

--- a/packages/ember-l10n/tests/unit/utils/message-utils-test.js
+++ b/packages/ember-l10n/tests/unit/utils/message-utils-test.js
@@ -2,7 +2,6 @@ import {
   replacePlaceholders,
   sanitizeMessageId,
   sanitizeJSON,
-  setupPluralFactory,
 } from '@ember-gettext/ember-l10n/utils/message-utils';
 import { module, test } from 'qunit';
 
@@ -143,34 +142,6 @@ module('Unit | Utility | message-utils', function () {
           },
         },
       });
-    });
-  });
-
-  module('setupPluralFactory', function () {
-    test('it works with a standard plural form: nplurals=2; plural=(n != 1);', function (assert) {
-      let pluralForm = 'nplurals=2; plural=(n != 1);';
-      let result = setupPluralFactory(pluralForm, pluralForm);
-
-      assert.equal(typeof result, 'function', 'result is a function');
-      assert.equal(result(0), 1, 'it works for 0');
-      assert.equal(result(1), 0, 'it works for 1');
-      assert.equal(result(2), 1, 'it works for 2');
-      assert.equal(result(3), 1, 'it works for 3');
-      assert.equal(result(3000), 1, 'it works for 3000');
-      assert.equal(result(-1), 1, 'it works for -1');
-    });
-
-    test('it works with nplurals=1; plural=0;', function (assert) {
-      let pluralForm = 'nplurals=1; plural=0;';
-      let result = setupPluralFactory(pluralForm, pluralForm);
-
-      assert.equal(typeof result, 'function', 'result is a function');
-      assert.equal(result(0), 0, 'it works for 0');
-      assert.equal(result(1), 0, 'it works for 1');
-      assert.equal(result(2), 0, 'it works for 2');
-      assert.equal(result(3), 0, 'it works for 3');
-      assert.equal(result(3000), 0, 'it works for 3000');
-      assert.equal(result(-1), 0, 'it works for -1');
     });
   });
 });

--- a/packages/gettext-parser/lib/commands/convert.js
+++ b/packages/gettext-parser/lib/commands/convert.js
@@ -70,7 +70,7 @@ module.exports = {
       this.ui.writeLine('');
     }
 
-    let validationErrors = validate(poFileJson);
+    let validationErrors = validate(poFileJson, { locale });
 
     printValidationErrors(validationErrors, { ui: this.ui });
 

--- a/packages/gettext-parser/lib/utils/validate-json.js
+++ b/packages/gettext-parser/lib/utils/validate-json.js
@@ -3,18 +3,36 @@ const {
   validateTranslatedPlaceholders,
 } = require('./validate/validate-translated-placeholders');
 const { traverseJson } = require('./traverse-json');
+const { validatePluralForms } = require('./validate/validate-plural-forms');
+const {
+  validatePluralFormFormat,
+} = require('./validate/validate-plural-form-format');
 
-function validate(json) {
+function validate(json, { locale }) {
   let validationErrors = [];
-  traverseJson(json, (item) => validateItem(item, validationErrors));
+
+  // Validate if plural form handling works properly
+  let pluralForm = json.headers['plural-forms'];
+  validatePluralFormFormat(pluralForm, locale);
+
+  let pluralRules = new Intl.PluralRules(locale);
+  let { pluralCategories } = pluralRules.resolvedOptions();
+
+  traverseJson(json, (item) =>
+    validateItem(item, { pluralCategories }, validationErrors)
+  );
   return validationErrors;
 }
 
-function validateItem(item, validationErrors) {
+function validateItem(item, { pluralCategories }, validationErrors) {
   let { msgid: id, msgid_plural: idPlural, msgstr: translations } = item;
 
   validatePlaceholders({ id, idPlural, translations }, validationErrors);
   validateTranslatedPlaceholders({ id, translations }, validationErrors);
+  validatePluralForms(
+    { id, idPlural, translations, pluralCategories },
+    validationErrors
+  );
 }
 
 module.exports = {

--- a/packages/gettext-parser/lib/utils/validate/validate-plural-form-format.js
+++ b/packages/gettext-parser/lib/utils/validate/validate-plural-form-format.js
@@ -1,0 +1,86 @@
+const PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
+
+function validatePluralFormFormat(pluralForm, locale) {
+  let pluralRules = new Intl.PluralRules(locale);
+  let { pluralCategories, locale: parsedLocale } =
+    pluralRules.resolvedOptions();
+
+  // We want to ensure a stable sorting
+  // As this could be in any order, but gettext will try to keep a stable ordering from few->many
+  let sortedPluralCategories = PLURAL_FORMS.filter((pluralForm) =>
+    pluralCategories.includes(pluralForm)
+  );
+
+  if (!parsedLocale.includes(locale)) {
+    throw new Error(
+      `given locale could not be identified correctly for pluralization purposes - is: "${locale}" but is parsed as "${parsedLocale}"`
+    );
+  }
+
+  let parsedPluralFactory = setupPluralFactory(pluralForm);
+
+  let usedCategories = [];
+
+  // PO only accounts for positive numbers, so we do not check negative ones
+  for (let i = 0; i <= 10000; i++) {
+    let pos = parsedPluralFactory(i);
+
+    let parsedCategory = sortedPluralCategories[pos];
+    let category = pluralRules.select(i);
+
+    if (typeof parsedCategory === 'undefined') {
+      throw new Error(
+        `plural-form header does not match Intl.PluralRules(). It is "${pluralForm}", which does not map to ${JSON.stringify(
+          sortedPluralCategories
+        )}`
+      );
+    }
+
+    if (category !== parsedCategory) {
+      throw new Error(
+        `plural-form header does not match Intl.PluralRules(). Parsed plural for ${i} is ${parsedCategory}, but should be ${category}`
+      );
+    }
+
+    if (!usedCategories.includes(parsedCategory)) {
+      usedCategories.push(parsedCategory);
+    }
+  }
+}
+
+// This code was previously used to parse plural forms by ember-l10n
+// Takes something like: nplurals=2; plural=(n != 1); or nplurals=1; plural=0;
+function setupPluralFactory(pluralForm) {
+  let regex =
+    /^\s*nplurals=\s*(\d+)\s*;\s*plural\s*=\s*([-+*/%?!&|=<>():;n\d\s]+);$/;
+
+  if (!pluralForm || !pluralForm.match(regex)) {
+    throw new Error('No plural-form header is present');
+  }
+
+  let maxMessageIndex, pluralExpression;
+  let m;
+  if ((m = regex.exec(pluralForm)) !== null) {
+    maxMessageIndex = m[1] * 1 - 1;
+    pluralExpression = m[2];
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  return (n) => {
+    let pluralPos = eval(pluralExpression);
+
+    if (typeof pluralPos !== 'number') {
+      pluralPos = pluralPos ? 1 : 0;
+    }
+
+    if (pluralPos > maxMessageIndex) {
+      return 0;
+    }
+
+    return pluralPos;
+  };
+}
+
+module.exports = {
+  validatePluralFormFormat,
+};

--- a/packages/gettext-parser/lib/utils/validate/validate-plural-forms.js
+++ b/packages/gettext-parser/lib/utils/validate/validate-plural-forms.js
@@ -1,0 +1,18 @@
+function validatePluralForms(
+  { id, idPlural, translations, pluralCategories },
+  validationErrors
+) {
+  if (idPlural && translations.length !== pluralCategories.length) {
+    validationErrors.push({
+      id,
+      translation: JSON.stringify(translations),
+      message: `The number of plural forms does not match the expected amount. 
+expected forms: ${JSON.stringify(pluralCategories)}`,
+      level: 'WARNING',
+    });
+  }
+}
+
+module.exports = {
+  validatePluralForms,
+};

--- a/packages/gettext-parser/node-tests/unit/commands/utils/validate/validate-plural-form-format-test.js
+++ b/packages/gettext-parser/node-tests/unit/commands/utils/validate/validate-plural-form-format-test.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai');
+const {
+  validatePluralFormFormat,
+} = require('./../../../../../lib/utils/validate/validate-plural-form-format');
+
+// This is heavily based on: https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
+describe('validatePluralFormFormat util', function () {
+  describe('throws on errors', function () {
+    it(`it throws on invalid format for de`, function () {
+      expect(() =>
+        validatePluralFormFormat('nplurals=1; plural=0;', 'de')
+      ).to.throw(
+        'plural-form header does not match Intl.PluralRules(). Parsed plural for 0 is one, but should be other'
+      );
+    });
+  });
+
+  describe('only one form', function () {
+    ['ko', 'ja', 'vi'].forEach((locale) => {
+      it(`it works for ${locale}`, function () {
+        validatePluralFormFormat('nplurals=1; plural=0;', locale);
+      });
+    });
+  });
+
+  describe('two forms, singular used for one only', function () {
+    ['en', 'de', 'nl', 'sv', 'no', 'it', 'es', 'el', 'hu', 'tr'].forEach(
+      (locale) => {
+        it(`it works for ${locale}`, function () {
+          validatePluralFormFormat('nplurals=2; plural=(n != 1);', locale);
+        });
+      }
+    );
+  });
+
+  describe('two forms, singular used for zero and one', function () {
+    // We ignore pt-BR for now, as that is not properly parsed
+    ['pt', 'fr'].forEach((locale) => {
+      it(`it works for ${locale}`, function () {
+        validatePluralFormFormat('nplurals=2; plural=n>1;', locale);
+      });
+    });
+  });
+
+  describe('three forms, special cases for numbers ending in 1 and 2, 3, 4, except those ending in 1[1-4]', function () {
+    ['ru', 'uk', 'sr', 'hr'].forEach((locale) => {
+      it(`it works for ${locale}`, function () {
+        validatePluralFormFormat(
+          'nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;',
+          locale
+        );
+      });
+    });
+  });
+
+  describe('six forms, special cases for one, two, all numbers ending in 02, 03, … 10, all numbers ending in 11 … 99, and other', function () {
+    ['ar'].forEach((locale) => {
+      it(`it works for ${locale}`, function () {
+        validatePluralFormFormat(
+          ' nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;',
+          locale
+        );
+      });
+    });
+  });
+});

--- a/packages/gettext-parser/translations/ko.json
+++ b/packages/gettext-parser/translations/ko.json
@@ -1,0 +1,69 @@
+{
+  "charset": "utf-8",
+  "headers": {
+    "project-id-version": "gettext-parser 0.0.0",
+    "pot-creation-date": "2021-05-10T07:52:44.847Z",
+    "po-revision-date": "2021-05-10T07:52:44.847Z",
+    "language": "ko",
+    "mime-version": "1.0",
+    "content-type": "text/plain; charset=utf-8",
+    "content-transfer-encoding": "8bit",
+    "plural-forms": "nplurals=1; plural=0;"
+  },
+  "translations": {
+    "": {
+      "Hello world!": {
+        "msgid": "Hello world!",
+        "msgstr": [
+          "Hallo Welt!"
+        ]
+      },
+      "Multi-line translations\nwork!": {
+        "msgid": "Multi-line translations\nwork!",
+        "msgstr": [
+          "Mehrzeilige Uebersetzungen\nfunktionieren!"
+        ]
+      },
+      "My name is {{name}}.": {
+        "msgid": "My name is {{name}}.",
+        "msgstr": [
+          "Mein Name ist {{name}}."
+        ]
+      },
+      "Read more in our {{#1}}guide{{/1}} or {{#2}}help{{/2}}.": {
+        "msgid": "Read more in our {{#1}}guide{{/1}} or {{#2}}help{{/2}}.",
+        "msgstr": [
+          "Lies mehr in unserer {{#1}}Anleitung{{/1}} oder {{#2}}Hilfe{{/2}}."
+        ]
+      },
+      "This page only contains text for tests": {
+        "msgid": "This page only contains text for tests",
+        "msgstr": [
+          "Diese Seite enthaelt Text fuer Tests."
+        ]
+      },
+      "Translations with\n<strong>tags</strong> and weird indentation\nworks": {
+        "msgid": "Translations with\n<strong>tags</strong> and weird indentation\nworks",
+        "msgstr": [
+          "Uebersetzungen mit\n<strong>Tags</storng und seltsamer Einrueckung\nfunktionieren"
+        ]
+      },
+      "You have {{count}} unit in your cart.": {
+        "msgid": "You have {{count}} unit in your cart.",
+        "msgid_plural": "You have {{count}} units in your cart.",
+        "msgstr": [
+          "Du hast {{count}} Einheit in deinem Warenkorb."
+        ]
+      }
+    },
+    "menu": {
+      "User": {
+        "msgid": "User",
+        "msgctxt": "menu",
+        "msgstr": [
+          "Benuzter"
+        ]
+      }
+    }
+  }
+}

--- a/packages/gettext-parser/translations/ko.po
+++ b/packages/gettext-parser/translations/ko.po
@@ -1,0 +1,69 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: gettext-parser 0.0.0\n"
+"POT-Creation-Date: 2021-05-10T07:52:44.847Z\n"
+"PO-Revision-Date: 2021-05-10T07:52:44.847Z\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;"
+
+#: node-tests/fixtures/test-app/app/controllers/application.js:12:10
+#: node-tests/fixtures/test-app/app/templates/test-page.hbs:19:0
+#: node-tests/fixtures/test-app/app/templates/test-page.hbs:20:0
+msgid "en"
+msgstr "en"
+
+#: node-tests/fixtures/test-app/app/controllers/application.js:13:10
+msgid "de"
+msgstr "de"
+
+#: node-tests/fixtures/test-app/app/controllers/application.js:14:10
+msgid "ko"
+msgstr "ko"
+
+#: node-tests/fixtures/test-app/app/templates/application.hbs:38:0
+msgid "Hello world!"
+msgstr "Hallo Welt!"
+
+#: node-tests/fixtures/test-app/app/templates/application.hbs:65:2
+#: node-tests/fixtures/test-app/app/templates/application.hbs:78:2
+msgid "You have {{count}} unit in your cart."
+msgid_plural "You have {{count}} units in your cart."
+msgstr[0] "Du hast {{count}} Einheit in deinem Warenkorb."
+
+#: node-tests/fixtures/test-app/app/templates/application.hbs:101:0
+msgid "My name is {{name}}."
+msgstr "Mein Name ist {{name}}."
+
+#: node-tests/fixtures/test-app/app/templates/application.hbs:119:0
+msgctxt "menu"
+msgid "User"
+msgstr "Benuzter"
+
+#: node-tests/fixtures/test-app/app/templates/application.hbs:129:11
+msgid "Read more in our {{#1}}guide{{/1}} or {{#2}}help{{/2}}."
+msgstr "Lies mehr in unserer {{#1}}Anleitung{{/1}} oder {{#2}}Hilfe{{/2}}."
+
+#: node-tests/fixtures/test-app/app/templates/test-page.hbs:2:2
+msgid "This page only contains text for tests"
+msgstr "Diese Seite enthaelt Text fuer Tests."
+
+#: node-tests/fixtures/test-app/app/templates/test-page.hbs:6:2
+msgid ""
+"Multi-line translations\n"
+"work!"
+msgstr ""
+"Mehrzeilige Uebersetzungen\n"
+"funktionieren!"
+
+#: node-tests/fixtures/test-app/app/templates/test-page.hbs:13:2
+msgid ""
+"Translations with\n"
+"<strong>tags</strong> and weird indentation\n"
+"works"
+msgstr ""
+"Uebersetzungen mit\n"
+"<strong>Tags</storng und seltsamer Einrueckung\n"
+"funktionieren"


### PR DESCRIPTION
This changes how we handle plural forms in our application.

We now use [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) instead of manually parsing a regex. This should be more stable and performant, and is supported in Safari 13+.

I built some tests to make sure the regular gettext plural handling matches this, to ensure the order of plural forms etc. continues to work.

This is _potentially_ breaking if you've been relying on some tricky plural form handling. I wrote tests for a list of common locales, which should all continue to work as expected, but you _might_ run into problems with smaller/less common locales.

If that happens, please open an issue. I included validation so that you should find out when trying to convert a JSON file.