### PR TITLE
feat: Remove chartset from JSON & only keep minimal headers

### DIFF
--- a/packages/gettext-parser/lib/commands/convert.js
+++ b/packages/gettext-parser/lib/commands/convert.js
@@ -72,6 +72,14 @@ module.exports = {
 
     let validationErrors = validate(poFileJson, { locale });
 
+    // Cleanup JSON output
+    let headers = {
+      locale,
+      'json-creation-date': new Date().toISOString(),
+    };
+    poFileJson.headers = headers;
+    delete poFileJson.charset;
+
     printValidationErrors(validationErrors, { ui: this.ui });
 
     if (validationErrors.some((error) => error.level === 'ERROR')) {

--- a/packages/gettext-parser/node-tests/acceptance/commands/convert-test.js
+++ b/packages/gettext-parser/node-tests/acceptance/commands/convert-test.js
@@ -58,6 +58,9 @@ describe('convert command', function () {
       './node-tests/fixtures/convert/expected.json'
     );
 
+    delete actualFileContent.headers['json-creation-date'];
+    delete expectedFileContent.headers['json-creation-date'];
+
     expect(actualFileContent).to.deep.equals(expectedFileContent);
 
     // Ensure order of props is correct as well
@@ -100,41 +103,8 @@ describe('convert command', function () {
       './node-tests/fixtures/convert/expected.json'
     );
 
-    expect(actualFileContent).to.deep.equals(expectedFileContent);
-  });
-
-  it('it appends a semicolon to the plural forms if it is missing', async function () {
-    let options = getOptions({});
-
-    // First put the example en.po in the output folder
-    fs.copyFileSync(
-      './node-tests/fixtures/convert/en-plural-form-no-semicolon.po',
-      `${TMP_DIR}/en.po`
-    );
-
-    let cmd = createCommand();
-    await cmd.run(options);
-
-    let actualFileContent = readJSONFromFile('./tmp/ember-l10n-tests/en.json');
-    let expectedFileContent = {
-      charset: 'utf-8',
-      headers: {
-        'content-transfer-encoding': '8bit',
-        'content-type': 'text/plain; charset=UTF-8',
-        language: 'en',
-        'language-team': 'none',
-        'last-translator': 'Automatically generated',
-        'mime-version': '1.0',
-        'plural-forms': 'nplurals=2; plural=(n != 1);',
-        'po-revision-date': '2018-07-20 08:39+0200',
-        'pot-creation-date': '2018-07-20 08:39+0200',
-        'project-id-version': 'My App 1.0',
-        'report-msgid-bugs-to': 'support@mycompany.com',
-      },
-      translations: {
-        '': {},
-      },
-    };
+    delete actualFileContent.headers['json-creation-date'];
+    delete expectedFileContent.headers['json-creation-date'];
 
     expect(actualFileContent).to.deep.equals(expectedFileContent);
   });

--- a/packages/gettext-parser/node-tests/fixtures/convert/expected.json
+++ b/packages/gettext-parser/node-tests/fixtures/convert/expected.json
@@ -1,67 +1,40 @@
 {
-  "charset": "utf-8",
   "headers": {
-    "project-id-version": "My App 1.0",
-    "report-msgid-bugs-to": "support@mycompany.com",
-    "pot-creation-date": "2018-07-20 08:39+0200",
-    "po-revision-date": "2018-07-20 08:39+0200",
-    "last-translator": "Automatically generated",
-    "language-team": "none",
-    "language": "en",
-    "mime-version": "1.0",
-    "content-type": "text/plain; charset=UTF-8",
-    "content-transfer-encoding": "8bit",
-    "plural-forms": "nplurals=2; plural=(n != 1);"
+    "locale": "en"
   },
   "translations": {
     "": {
       "\"double quotes\" and 'single quotes'": {
         "msgid": "\"double quotes\" and 'single quotes'",
-        "msgstr": [
-          "\"double quotes\" and 'single quotes'"
-        ]
+        "msgstr": ["\"double quotes\" and 'single quotes'"]
       },
       "Current status: {{status}}": {
         "msgid": "Current status: {{status}}",
-        "msgstr": [
-          "Derzeitiger Status: {{status}}"
-        ]
+        "msgstr": ["Derzeitiger Status: {{status}}"]
       },
       "de": {
         "msgid": "de",
-        "msgstr": [
-          "Deutsch"
-        ]
+        "msgstr": ["Deutsch"]
       },
       "en": {
         "msgid": "en",
-        "msgstr": [
-          "Englisch"
-        ]
+        "msgstr": ["Englisch"]
       },
       "Hello world!": {
         "msgid": "Hello world!",
-        "msgstr": [
-          "Hallo Welt!"
-        ]
+        "msgstr": ["Hallo Welt!"]
       },
       "I'm a {{placeholder}}.": {
         "msgid": "I'm a {{placeholder}}.",
-        "msgstr": [
-          "Ich bin ein {{placeholder}}."
-        ]
+        "msgstr": ["Ich bin ein {{placeholder}}."]
       },
       "ko": {
         "msgid": "ko",
-        "msgstr": [
-          "Koreanisch"
-        ]
+        "msgstr": ["Koreanisch"]
       },
       "My name is {{name}}.": {
         "msgid": "My name is {{name}}.",
-        "msgstr": [
-          "Mein Name ist {{name}}."
-        ]
+        "msgstr": ["Mein Name ist {{name}}."]
       },
       "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.": {
         "msgid": "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.",
@@ -71,15 +44,11 @@
       },
       "STATUS_ACTIVE": {
         "msgid": "STATUS_ACTIVE",
-        "msgstr": [
-          "Aktiv"
-        ]
+        "msgstr": ["Aktiv"]
       },
       "testing": {
         "msgid": "testing",
-        "msgstr": [
-          "testend"
-        ]
+        "msgstr": ["testend"]
       },
       "You have {{count}} unit in your cart.": {
         "msgid": "You have {{count}} unit in your cart.",
@@ -95,19 +64,13 @@
         "msgid": "user",
         "msgctxt": "menu",
         "msgid_plural": "users",
-        "msgstr": [
-          "Benutzer",
-          "Benuzter"
-        ]
+        "msgstr": ["Benutzer", "Benuzter"]
       },
       "You have {{count}} subscription": {
         "msgid": "You have {{count}} subscription",
         "msgctxt": "menu",
         "msgid_plural": "You have {{count}} subscriptions",
-        "msgstr": [
-          "Du hast {{count}} Account",
-          "Du hast {{count}} Accounts"
-        ]
+        "msgstr": ["Du hast {{count}} Account", "Du hast {{count}} Accounts"]
       }
     }
   }

--- a/packages/gettext-parser/translations/de.json
+++ b/packages/gettext-parser/translations/de.json
@@ -1,15 +1,7 @@
 {
-  "charset": "utf-8",
   "headers": {
-    "project-id-version": "gettext-parser 0.0.0",
-    "pot-creation-date": "2021-05-10T07:52:44.847Z",
-    "po-revision-date": "2021-05-10T07:52:44.847Z",
-    "language": "de",
-    "mime-version": "1.0",
-    "content-type": "text/plain; charset=utf-8",
-    "content-transfer-encoding": "8bit",
-    "last-translator": "Generated from source",
-    "plural-forms": "nplurals=2; plural=(n != 1);"
+    "locale": "de",
+    "json-creation-date": "2021-07-13T06:07:42.511Z"
   },
   "translations": {
     "": {

--- a/packages/gettext-parser/translations/en.json
+++ b/packages/gettext-parser/translations/en.json
@@ -1,15 +1,7 @@
 {
-  "charset": "utf-8",
   "headers": {
-    "project-id-version": "gettext-parser 0.0.0",
-    "pot-creation-date": "2021-05-10T07:52:44.849Z",
-    "po-revision-date": "2021-05-10T07:52:44.849Z",
-    "language": "en",
-    "mime-version": "1.0",
-    "content-type": "text/plain; charset=utf-8",
-    "content-transfer-encoding": "8bit",
-    "last-translator": "Generated from source",
-    "plural-forms": "nplurals=2; plural=(n != 1);"
+    "json-creation-date": "2021-07-12T15:29:45.097Z",
+    "locale": "en"
   },
   "translations": {
     "": {},

--- a/packages/gettext-parser/translations/ko.json
+++ b/packages/gettext-parser/translations/ko.json
@@ -1,15 +1,4 @@
 {
-  "charset": "utf-8",
-  "headers": {
-    "project-id-version": "gettext-parser 0.0.0",
-    "pot-creation-date": "2021-05-10T07:52:44.847Z",
-    "po-revision-date": "2021-05-10T07:52:44.847Z",
-    "language": "ko",
-    "mime-version": "1.0",
-    "content-type": "text/plain; charset=utf-8",
-    "content-transfer-encoding": "8bit",
-    "plural-forms": "nplurals=1; plural=0;"
-  },
   "translations": {
     "": {
       "Hello world!": {


### PR DESCRIPTION
As we do not actually need/care about most of these fields anymore.

This is breaking if you try to generate json files with the new version of gettext-parser to be used with an old version of ember-l10n. If you update them in lockstep, everything will be fine.