### PR TITLE
feat: Use canonical region locale names (e.g. `en-US` instead of `en_US`)

### DIFF
--- a/packages/ember-l10n/addon/utils/guess-locale.js
+++ b/packages/ember-l10n/addon/utils/guess-locale.js
@@ -5,18 +5,18 @@ import { assert } from '@ember/debug';
  * This will return the best-fitting locale.
  *
  * Given the following input:
- * allowedLocales = ['en', 'de', 'zh_HK']
+ * allowedLocales = ['en', 'de', 'zh-HK']
  * desiredLocales = ['de-AT', 'de', 'en-US', 'en']
  *
  * It would by default return 'de'.
  *
- * If you specify `allowSubLocales=true`, it would instead return `de_AT`, the favorite sub-locale.
+ * If you specify `allowSubLocales=true`, it would instead return `de-AT`, the favorite sub-locale.
  *
  * In contrast, the following input:
- * allowedLocales = ['en', 'de', 'zh_HK']
+ * allowedLocales = ['en', 'de', 'zh-HK']
  * desiredLocales = ['zh-CN', 'zh-HK', 'en-US', 'en']
  *
- * Would always return 'zh_HK', no matter if sub locales are allowed or not.
+ * Would always return 'zh-HK', no matter if sub locales are allowed or not.
  */
 export function guessLocale({
   defaultLocale = 'en',
@@ -54,13 +54,9 @@ export function guessLocale({
 }
 
 function normalizeLocale(locale) {
-  locale = locale.replace('-', '_');
-  let [mainLocale, region] = locale.split('_');
-  if (region) {
-    return `${mainLocale}_${region.toUpperCase()}`;
-  }
+  let canonicalLocales = Intl.getCanonicalLocales(locale);
 
-  return mainLocale;
+  return canonicalLocales[0];
 }
 
 function getLocalAlias(locale) {
@@ -68,16 +64,16 @@ function getLocalAlias(locale) {
   // We need to map those to either Simplified (CN) or Traditional (HK).
   // Sadly, we cannot simply fall back to zh here, as that is not actually a valid locale
   switch (locale) {
-    case 'zh_CN':
-    case 'zh_SG':
-    case 'zh_HANS':
+    case 'zh-CN':
+    case 'zh-SG':
+    case 'zh-Hans':
     case 'zh':
-      return 'zh_CN';
-    case 'zh_HK':
-    case 'zh_TW':
-    case 'zh_MO':
-    case 'zh_HANT':
-      return 'zh_HK';
+      return 'zh-CN';
+    case 'zh-HK':
+    case 'zh-TW':
+    case 'zh-MO':
+    case 'zh-Hant':
+      return 'zh-HK';
   }
 
   return locale;

--- a/packages/ember-l10n/tests/unit/utils/detect-locale-test.js
+++ b/packages/ember-l10n/tests/unit/utils/detect-locale-test.js
@@ -32,7 +32,7 @@ module('Unit | Utility | detect-locale', function () {
     let detectedLocale = detectLocale({
       defaultLocale: 'en',
       availableLocales: ['en', 'ko', 'de'],
-      navigator: mockNavigator(['de_AT']),
+      navigator: mockNavigator(['de-AT']),
     });
 
     assert.equal(detectedLocale, 'de');
@@ -51,11 +51,11 @@ module('Unit | Utility | detect-locale', function () {
   test('it works with Chinese locales', function (assert) {
     let detectedLocale = detectLocale({
       defaultLocale: 'en',
-      availableLocales: ['en', 'ko', 'zh_HK', 'jp'],
-      navigator: mockNavigator(['de-AT', 'zh_TW']),
+      availableLocales: ['en', 'ko', 'zh-HK', 'jp'],
+      navigator: mockNavigator(['de-AT', 'zh-TW']),
     });
 
-    assert.equal(detectedLocale, 'zh_HK');
+    assert.equal(detectedLocale, 'zh-HK');
   });
 
   test('it works with no detected locale', function (assert) {

--- a/packages/ember-l10n/tests/unit/utils/guess-locale-test.js
+++ b/packages/ember-l10n/tests/unit/utils/guess-locale-test.js
@@ -16,7 +16,7 @@ module('Unit | Utility | guess-locale', function () {
     let guessedLocale = guessLocale({
       defaultLocale: 'en',
       availableLocales: ['en'],
-      desiredLocales: ['en_US'],
+      desiredLocales: ['en-US'],
     });
 
     assert.equal(guessedLocale, 'en');
@@ -26,7 +26,7 @@ module('Unit | Utility | guess-locale', function () {
     let guessedLocale = guessLocale({
       defaultLocale: 'en',
       availableLocales: ['de'],
-      desiredLocales: ['de_AT'],
+      desiredLocales: ['de-AT'],
     });
 
     assert.equal(guessedLocale, 'de');
@@ -35,18 +35,18 @@ module('Unit | Utility | guess-locale', function () {
   test('it detects sub-locales if allowed', function (assert) {
     let guessedLocale = guessLocale({
       defaultLocale: 'en',
-      availableLocales: ['de_AT'],
-      desiredLocales: ['de_DE', 'de_AT'],
+      availableLocales: ['de-AT'],
+      desiredLocales: ['de-DE', 'de-AT'],
     });
 
-    assert.equal(guessedLocale, 'de_AT');
+    assert.equal(guessedLocale, 'de-AT');
   });
 
   test('it works with multiple locales', function (assert) {
     let guessedLocale = guessLocale({
       defaultLocale: 'en',
       availableLocales: ['ko', 'en', 'de'],
-      desiredLocales: ['fr', 'de_AT'],
+      desiredLocales: ['fr', 'de-AT'],
     });
 
     assert.equal(guessedLocale, 'de');
@@ -65,37 +65,37 @@ module('Unit | Utility | guess-locale', function () {
   test('it normalizes desired locales', function (assert) {
     let guessedLocale = guessLocale({
       defaultLocale: 'en',
-      availableLocales: ['ko', 'en', 'de_AT'],
+      availableLocales: ['ko', 'en', 'de-AT'],
       desiredLocales: ['fr', 'de-AT'],
     });
 
-    assert.equal(guessedLocale, 'de_AT');
+    assert.equal(guessedLocale, 'de-AT');
   });
 
   module('simplified Chinese locales', function () {
-    ['zh-CN', 'zh_CN', 'zh', 'zh_Hans', 'zh-SG'].forEach((locale) => {
-      test(`it normalizes "${locale}" to zh_CN`, function (assert) {
+    ['zh-CN', 'zh-CN', 'zh', 'zh-Hans', 'zh-SG'].forEach((locale) => {
+      test(`it normalizes "${locale}" to zh-CN`, function (assert) {
         let guessedLocale = guessLocale({
           defaultLocale: 'en',
-          availableLocales: ['ko', 'en', 'zh_CN'],
+          availableLocales: ['ko', 'en', 'zh-CN'],
           desiredLocales: ['fr', locale],
         });
 
-        assert.equal(guessedLocale, 'zh_CN');
+        assert.equal(guessedLocale, 'zh-CN');
       });
     });
   });
 
   module('traditional Chinese locales', function () {
-    ['zh-HK', 'zh_HK', 'zh_TW', 'zh_Hant', 'zh_MO'].forEach((locale) => {
-      test(`it normalizes "${locale}" to zh_HK`, function (assert) {
+    ['zh-HK', 'zh-HK', 'zh-TW', 'zh-Hant', 'zh-MO'].forEach((locale) => {
+      test(`it normalizes "${locale}" to zh-HK`, function (assert) {
         let guessedLocale = guessLocale({
           defaultLocale: 'en',
-          availableLocales: ['ko', 'en', 'zh_HK'],
+          availableLocales: ['ko', 'en', 'zh-HK'],
           desiredLocales: ['fr', locale],
         });
 
-        assert.equal(guessedLocale, 'zh_HK');
+        assert.equal(guessedLocale, 'zh-HK');
       });
     });
   });


### PR DESCRIPTION
This is a breaking change, as it means region-specific locales have to be e.g. `en-US` instead of `en_US`. The former is the standard and actually correct. Note you have to update both the locale definition in your `config/environment.js` as well as rename your files to e.g. `en-US.json`.

If you have not been using region-specific locales (e.g. `en-US`), nothing changes for you.