### PR TITLE
feat: Cache locale data to avoid repeated fetches

### DIFF
--- a/packages/ember-l10n/tests/unit/services/l10n-test.js
+++ b/packages/ember-l10n/tests/unit/services/l10n-test.js
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import L10nService from '@ember-gettext/ember-l10n/services/l10n';
+import L10nService, {
+  clearLocaleCache,
+} from '@ember-gettext/ember-l10n/services/l10n';
 import { mockLocale } from 'dummy/tests/helpers/mock-locale';
 
 module('Unit | Service | l10n', function (hooks) {
@@ -32,7 +34,11 @@ module('Unit | Service | l10n', function (hooks) {
     );
   });
 
-  module('locale loading', function () {
+  module('locale loading', function (hooks) {
+    hooks.beforeEach(function () {
+      clearLocaleCache();
+    });
+
     test('it works', async function (assert) {
       let l10n = this.owner.lookup('service:l10n');
 


### PR DESCRIPTION
Currently, e.g. in acceptance tests it will re-load the locale files (e.g. `en.json`) over and over again, for each tests. 
While this can be cached and thus mitigated, it is still an unnecessary overhead.

This PR introduces a simple cache for locale data. Unless you call `clearLocaleCache` manually (which should only really ever be relevant for testing locale-related stuff), it will only fetch each locale once, and then re-use the previous translations.