### PR TITLE
Ensure default blueprint runs on `ember install`

### DIFF
--- a/packages/ember-l10n/package.json
+++ b/packages/ember-l10n/package.json
@@ -82,8 +82,6 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "before": [
-      "broccoli-asset-rev"
-    ]
+    "defaultBlueprint": "ember-l10n"
   }
 }


### PR DESCRIPTION
Oops, since the default blueprint is not exactly the app name (as we have a namespace), we need to define the default blueprint.