### PR TITLE
Add documentation for sub-locales & assert for usage of underlines

### DIFF
--- a/packages/ember-l10n/README.md
+++ b/packages/ember-l10n/README.md
@@ -192,7 +192,17 @@ will be available as `{{text}}` to the named block.
 
 Locale files can be generated with [gettext-parser](./../gettext-parser).
 
-ember-l10n expects properly formatted .json files (e.g. `de.json`, `en.json`) , by default in the `./app.locales` folder of your app.
+ember-l10n expects properly formatted .json files (e.g. `de.json`, `en.json`),
+by default in the `./app.locales` folder of your app.
+
+Note that sub-locales will fall back to using the base locale, unless they are specifically defined.
+
+So if you have `availableLocales: ['en', 'de']`, you can use `l10n.setLocale('de-AT')`,
+which will load & set the `de` locale from `de.json`.
+If you had `availableLocales: ['en', 'de', 'de-AT']`,
+it would look for a dedicated `de-AT.json` translation file instead.
+
+Note that sub-locales are expected to be dasherized, not using underlines (so e.g. `de-AT`, not `de_AT`).
 
 ### Locale detection
 

--- a/packages/ember-l10n/addon/services/l10n.js
+++ b/packages/ember-l10n/addon/services/l10n.js
@@ -223,5 +223,10 @@ and then run \`ember gettext:convert\` to convert your .po files into usable loc
       `ember-l10n: Do not use the locale zh, as it is not a valid locale. Instead, use dedicated locales for traditional & simplified Chinese.`,
       !this.availableLocales.some((locale) => locale === 'zh')
     );
+
+    assert(
+      `ember-l10n: Do not use underlines to differentiate locales (e.g. en_GB). Instead, use dashes, which are ISO compliant, e.g. en-GB.`,
+      !this.availableLocales.some((locale) => locale.split('_').length > 1)
+    );
   }
 }


### PR DESCRIPTION
This updates the README with a paragraph about using sub-locales, as well as asserting that they do not use an invalid format.