### PR TITLE
Update plural forms handling

### DIFF
--- a/packages/ember-l10n/addon/services/l10n.js
+++ b/packages/ember-l10n/addon/services/l10n.js
@@ -193,10 +193,13 @@ and then run \`ember gettext:convert\` to convert your .po files into usable loc
 
     let json = sanitizeJSON(localeData);
 
-    let { translations: l10nTranslations } = json;
+    let { translations: l10nTranslations, headers } = json;
 
     this.l10nTranslations = l10nTranslations;
-    this.pluralFactory = new PluralFactory(locale);
+    this.pluralFactory = new PluralFactory(
+      locale,
+      headers['plural-forms-count']
+    );
 
     waiter.endAsync(token);
   }

--- a/packages/ember-l10n/addon/utils/plural-factory.js
+++ b/packages/ember-l10n/addon/utils/plural-factory.js
@@ -1,32 +1,40 @@
 const PLURAL_FORMS = ['zero', 'one', 'two', 'few', 'many', 'other'];
 
-const ALIAS_LOCALES = {
-  fr: 'pt',
-};
-
+// NOTE: Keep in sync with packages/gettext-parser/lib/utils/validate/validate-plural-form-format.js
 export class PluralFactory {
   locale;
   pluralRules;
-  pluralForms;
 
-  constructor(locale) {
+  map = new Map();
+
+  constructor(locale, pluralFormsCount) {
     this.locale = locale;
 
-    let aliasLocale = ALIAS_LOCALES[locale];
-
-    this.pluralRules = new Intl.PluralRules(aliasLocale || locale);
+    this.pluralRules = new Intl.PluralRules(locale);
 
     // We want to ensure a stable sorting
     // As this could be in any order, but gettext will try to keep a stable ordering from few->many
     let pluralForms = this.pluralRules.resolvedOptions().pluralCategories;
 
-    this.pluralForms = PLURAL_FORMS.filter((pluralForm) =>
+    let sortedPluralForms = PLURAL_FORMS.filter((pluralForm) =>
       pluralForms.includes(pluralForm)
     );
+
+    let maxMessageId = pluralFormsCount
+      ? pluralFormsCount - 1
+      : sortedPluralForms.length - 1;
+
+    // If Intl.PluralRules has more plural forms than PO, we use the last one (usually many or other) for any "higher" form
+    for (let i = 0; i < sortedPluralForms.length; i++) {
+      let form = sortedPluralForms[i];
+      let messageId = Math.min(i, maxMessageId);
+      this.map.set(form, messageId);
+    }
   }
 
   getMessageIndex(count) {
     let pluralForm = this.pluralRules.select(count);
-    return this.pluralForms.indexOf(pluralForm);
+
+    return this.map.has(pluralForm) ? this.map.get(pluralForm) : 0;
   }
 }

--- a/packages/ember-l10n/tests/dummy/app/locales/en.json
+++ b/packages/ember-l10n/tests/dummy/app/locales/en.json
@@ -1,15 +1,8 @@
 {
-  "charset": "utf-8",
   "headers": {
-    "project-id-version": "@ember-gettext/ember-l10n 0.2.1",
-    "pot-creation-date": "2021-05-10T13:53:54.842Z",
-    "po-revision-date": "2021-05-10T13:53:54.842Z",
-    "language": "en",
-    "mime-version": "1.0",
-    "content-type": "text/plain; charset=utf-8",
-    "content-transfer-encoding": "8bit",
-    "last-translator": "Generated from source",
-    "plural-forms": "nplurals=2; plural=(n != 1);"
+    "locale": "en",
+    "json-creation-date": "2022-09-27T10:39:58.026Z",
+    "plural-forms-count": 2
   },
   "translations": {
     "": {}

--- a/packages/gettext-parser/lib/commands/convert.js
+++ b/packages/gettext-parser/lib/commands/convert.js
@@ -5,6 +5,7 @@ const gettextParser = require('gettext-parser');
 const { processJSON } = require('./../utils/process-json');
 const { validate } = require('./../utils/validate-json');
 const generateMap = require('./../utils/generate-map');
+const parsePluralFormsCount = require('./../utils/parse-plural-forms');
 
 module.exports = {
   name: 'gettext:convert',
@@ -120,10 +121,15 @@ module.exports = {
 
     let validationErrors = validate(poFileJson, { locale });
 
+    let pluralFormsCount = parsePluralFormsCount(
+      poFileJson.headers['plural-forms']
+    );
+
     // Cleanup JSON output
     let headers = {
       locale,
       'json-creation-date': new Date().toISOString(),
+      'plural-forms-count': pluralFormsCount,
     };
     poFileJson.headers = headers;
     delete poFileJson.charset;

--- a/packages/gettext-parser/lib/utils/parse-plural-forms.js
+++ b/packages/gettext-parser/lib/utils/parse-plural-forms.js
@@ -1,0 +1,23 @@
+// Takes something like: nplurals=2; plural=(n != 1); or nplurals=1; plural=0;
+// And parses our the `nplurals=X` part
+module.exports = function parsePluralFormsCount(pluralForm) {
+  if (!pluralForm) {
+    return undefined;
+  }
+
+  let regex = /nplurals(\s*)=(\s*)(\d+);/;
+
+  let match = pluralForm.match(regex);
+
+  if (!match) {
+    return undefined;
+  }
+
+  let nplurals = parseInt(match[3]);
+
+  if (Number.isNaN(nplurals)) {
+    return undefined;
+  }
+
+  return nplurals;
+};

--- a/packages/gettext-parser/node-tests/fixtures/convert/expected.json
+++ b/packages/gettext-parser/node-tests/fixtures/convert/expected.json
@@ -1,6 +1,7 @@
 {
   "headers": {
-    "locale": "en"
+    "locale": "en",
+    "plural-forms-count": 2
   },
   "translations": {
     "": {

--- a/packages/gettext-parser/node-tests/unit/commands/utils/validate/validate-plural-form-format-test.js
+++ b/packages/gettext-parser/node-tests/unit/commands/utils/validate/validate-plural-form-format-test.js
@@ -8,9 +8,9 @@ describe('validatePluralFormFormat util', function () {
   describe('throws on errors', function () {
     it(`it throws on invalid format for de`, function () {
       expect(() =>
-        validatePluralFormFormat('nplurals=1; plural=0;', 'de')
+        validatePluralFormFormat('nplurals=2; plural=0;', 'de')
       ).to.throw(
-        'plural-form header does not match Intl.PluralRules(). Parsed plural for 0 is one, but should be other'
+        'plural-form header does not match Intl.PluralRules() for number 0. Expected pos 0 but was 1.'
       );
     });
   });

--- a/packages/gettext-parser/translations-json/de.json
+++ b/packages/gettext-parser/translations-json/de.json
@@ -1,7 +1,8 @@
 {
   "headers": {
     "locale": "de",
-    "json-creation-date": "2021-11-25T16:09:24.659Z"
+    "json-creation-date": "2022-09-27T10:33:46.327Z",
+    "plural-forms-count": 2
   },
   "translations": {
     "": {

--- a/packages/gettext-parser/translations-json/en.json
+++ b/packages/gettext-parser/translations-json/en.json
@@ -1,7 +1,8 @@
 {
   "headers": {
     "locale": "en",
-    "json-creation-date": "2021-11-25T16:09:24.688Z"
+    "json-creation-date": "2022-09-27T10:33:46.341Z",
+    "plural-forms-count": 2
   },
   "translations": {
     "": {},

--- a/packages/gettext-parser/translations-json/ko.json
+++ b/packages/gettext-parser/translations-json/ko.json
@@ -1,7 +1,8 @@
 {
   "headers": {
     "locale": "ko",
-    "json-creation-date": "2021-11-25T16:09:24.703Z"
+    "json-creation-date": "2022-09-27T10:33:46.353Z",
+    "plural-forms-count": 1
   },
   "translations": {
     "": {


### PR DESCRIPTION
Previously, we depended on `Intl.PluralForms` to perfectly match the plural rules from gettext.

With this change, we introduce some lenience there. Now, "higher" plural forms (e.g. many/other) will use the last plural form, if not found.

For example, `it` has `[one, many, other]` plural forms according to `Intl`, but just `[one, other]` according to gettext. Now, we simply use index 1 for either many or other in these cases. 

For this, we (optionally) store the # of plural forms from PO in the JSON header.
If this is available, we use it in the plural factory to ensure we don't try to access any messages "higher" than this.

This is fully backwards compatible - if the header does not exist, it will continue to use the current behavior (which will result in an `undefined` message). So it is recommended to run `yarn gettext:convert` to have fully updated JSON files.